### PR TITLE
Support for multiple transactions in one entry, falling back to data on Ntry level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ eggs
 .cache
 .requirements.installed
 *.xml
+*.ofx

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ eggs
 *.sublime*
 .cache
 .requirements.installed
+*.xml

--- a/src/ofxstatement/plugins/iso20022.py
+++ b/src/ofxstatement/plugins/iso20022.py
@@ -86,16 +86,17 @@ class Iso20022Parser(AbstractStatementParser):
     def _parse_statement_properties(self, tree: ET.ElementTree) -> None:
         stmt = self._get_statement_el(tree)
 
-        bnk = stmt.find("./s:Acct/s:Svcr/s:FinInstnId/s:BIC", self.xmlns)
+        bnk = stmt.find("./s:Acct/s:Svcr/s:FinInstnId/s:BICFI", self.xmlns)  # checked
         if bnk is None:
-            bnk = stmt.find("./s:Acct/s:Svcr/s:FinInstnId/s:Nm", self.xmlns)
-        ccy = stmt.find("./s:Acct/s:Ccy", self.xmlns)
-        bals = stmt.findall("./s:Bal", self.xmlns)
+            bnk = stmt.find("./s:Acct/s:Svcr/s:FinInstnId/s:Nm", self.xmlns)  # checked
+
         ibanfind = stmt.find(
             "./s:Ntry/s:NtryDtls/s:TxDtls/s:RltdPties/s:CdtrAcct/s:Id/s:IBAN",
             self.xmlns,
         )  # checked
         # assert iban is not None
+        ccy = stmt.find("./s:Acct/s:Ccy", self.xmlns)  # checked
+        bals = stmt.findall("./s:Bal", self.xmlns)  # checked
 
         acctCurrency = ccy.text if ccy is not None else None
         if acctCurrency:

--- a/src/ofxstatement/plugins/iso20022.py
+++ b/src/ofxstatement/plugins/iso20022.py
@@ -93,7 +93,7 @@ class Iso20022Parser(AbstractStatementParser):
         ibanfind = stmt.find(
             "./s:Ntry/s:NtryDtls/s:TxDtls/s:RltdPties/s:CdtrAcct/s:Id/s:IBAN",
             self.xmlns,
-        )  # checked
+        )  # checked, appears to not be included in every camt.053 statement?
         # assert iban is not None
         ccy = stmt.find("./s:Acct/s:Ccy", self.xmlns)  # checked
         bals = stmt.findall("./s:Bal", self.xmlns)  # checked

--- a/src/ofxstatement/plugins/iso20022.py
+++ b/src/ofxstatement/plugins/iso20022.py
@@ -87,17 +87,17 @@ class Iso20022Parser(AbstractStatementParser):
     def _parse_statement_properties(self, tree: ET.ElementTree) -> None:
         stmt = self._get_statement_el(tree)
 
-        bnk = stmt.find("./s:Acct/s:Svcr/s:FinInstnId/s:BICFI", self.xmlns)  # checked
+        bnk = stmt.find("./s:Acct/s:Svcr/s:FinInstnId/s:BICFI", self.xmlns)
         if bnk is None:
-            bnk = stmt.find("./s:Acct/s:Svcr/s:FinInstnId/s:Nm", self.xmlns)  # checked
+            bnk = stmt.find("./s:Acct/s:Svcr/s:FinInstnId/s:Nm", self.xmlns)
 
         ibanfind = stmt.find(
             "./s:Ntry/s:NtryDtls/s:TxDtls/s:RltdPties/s:CdtrAcct/s:Id/s:IBAN",
             self.xmlns,
-        )  # checked, appears to not be included in every camt.053 statement?
-        # assert iban is not None
-        ccy = stmt.find("./s:Acct/s:Ccy", self.xmlns)  # checked
-        bals = stmt.findall("./s:Bal", self.xmlns)  # checked
+        )
+
+        ccy = stmt.find("./s:Acct/s:Ccy", self.xmlns)
+        bals = stmt.findall("./s:Bal", self.xmlns)
 
         acctCurrency = ccy.text if ccy is not None else None
         if acctCurrency:

--- a/src/ofxstatement/plugins/iso20022.py
+++ b/src/ofxstatement/plugins/iso20022.py
@@ -29,7 +29,8 @@ class Iso20022Plugin(Plugin):
 
     def get_parser(self, filename: str) -> "Iso20022Parser":
         default_ccy = self.settings.get("currency")
-        parser = Iso20022Parser(filename, currency=default_ccy)
+        default_iban = self.settings.get("iban")
+        parser = Iso20022Parser(filename, currency=default_ccy, iban=default_iban)
         return parser
 
 
@@ -37,14 +38,18 @@ class Iso20022Parser(AbstractStatementParser):
     version: CamtVersion
     xmlns: Dict[str, str]
 
-    def __init__(self, filename: str, currency: Optional[str] = None):
+    def __init__(
+        self, filename: str, currency: Optional[str] = None, iban: Optional[str] = None
+    ):
         self.filename = filename
         self.currency = currency
+        self.iban = iban
 
     def parse(self) -> Statement:
         """Main entry point for parsers"""
         self.statement = Statement()
         self.statement.currency = self.currency
+        self.statement.account_id = self.iban
         tree = ET.parse(self.filename)
 
         # Find out XML namespace and make sure we can parse it
@@ -84,10 +89,13 @@ class Iso20022Parser(AbstractStatementParser):
         bnk = stmt.find("./s:Acct/s:Svcr/s:FinInstnId/s:BIC", self.xmlns)
         if bnk is None:
             bnk = stmt.find("./s:Acct/s:Svcr/s:FinInstnId/s:Nm", self.xmlns)
-        iban = stmt.find("./s:Acct/s:Id/s:IBAN", self.xmlns)
-        assert iban is not None
         ccy = stmt.find("./s:Acct/s:Ccy", self.xmlns)
         bals = stmt.findall("./s:Bal", self.xmlns)
+        ibanfind = stmt.find(
+            "./s:Ntry/s:NtryDtls/s:TxDtls/s:RltdPties/s:CdtrAcct/s:Id/s:IBAN",
+            self.xmlns,
+        )  # checked
+        # assert iban is not None
 
         acctCurrency = ccy.text if ccy is not None else None
         if acctCurrency:
@@ -98,6 +106,16 @@ class Iso20022Parser(AbstractStatementParser):
                     0,
                     "No account currency provided in statement. Please "
                     "specify one in configuration file (e.g. currency=EUR)",
+                )
+
+        acctIban = ibanfind.text if ibanfind is not None else None
+        if acctIban:
+            self.statement.account_id = acctIban
+        else:
+            if self.statement.account_id is None:
+                raise exceptions.ParseError(
+                    0,
+                    "No iban found in the statement. Please specify one in the configuration file (e.g. iban=CH...)",
                 )
 
         bal_amts = {}
@@ -124,7 +142,7 @@ class Iso20022Parser(AbstractStatementParser):
             )
 
         self.statement.bank_id = bnk.text if bnk is not None else None
-        self.statement.account_id = iban.text
+        self.statement.account_id = acctIban
 
         # From ISO 20022 Account Statement Guide:
         #


### PR DESCRIPTION

[CAMT053_300623_anonymized.xml.txt](https://github.com/kedder/ofxstatement-iso20022/files/11972216/CAMT053_300623_anonymized.xml.txt)
Attached is an example statement with the following properties which caused it to not be converted correctly:
* first <Ntry> has one transaction, so one <TxDtls>, everything fine with this
* second <Ntry> contains two transactions, so two <TxDtls>, of which without my changes the <Amt> would have been taken from the <Ntry> and attributed in full to the first <TxDtls>
* third <Ntry> contains one transaction without <TxDtls> so the new code handling multiple <TxDtls> per <Ntry> can only be used if there are any <TxDtls>

I’m not at all happy with how I implemented this but I had no good idea how to handle this more elegantly and with less repetition of code. I’m not a programmer, I just try to get things to work, so any advice is welcome!
