### PR TITLE
Reorder setting of memo field according to Postfinance, always record ref field as check_no

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
-"""Setup
-"""
+"""Setup"""
 from setuptools import find_packages
 from distutils.core import setup
 

--- a/src/ofxstatement/plugins/iso20022.py
+++ b/src/ofxstatement/plugins/iso20022.py
@@ -222,13 +222,14 @@ class Iso20022Parser(AbstractStatementParser):
         refinf = self._find(ntry, "NtryDtls/TxDtls/RmtInf/Strd/CdtrRefInf/Ref")
         rmtinf = self._find(ntry, "NtryDtls/TxDtls/RmtInf/Ustrd")
         addinf = self._find(ntry, "AddtlNtryInf")
-        if refinf is not None:
-            sline.memo = refinf.text
+
+        if addinf is not None:
+            sline.memo = addinf.text
         elif rmtinf is not None:
             sline.memo = rmtinf.text
-        elif addinf is not None:
-            sline.memo = addinf.text
-
+        if refinf is not None:
+            sline.check_no = refinf.text
+            sline.memo = sline.memo or refinf.text            
         return sline
 
     def _parse_date(self, dtnode: Optional[ET.Element]) -> Optional[datetime.datetime]:

--- a/src/ofxstatement/plugins/iso20022.py
+++ b/src/ofxstatement/plugins/iso20022.py
@@ -229,7 +229,7 @@ class Iso20022Parser(AbstractStatementParser):
             sline.memo = rmtinf.text
         if refinf is not None:
             sline.check_no = refinf.text
-            sline.memo = sline.memo or refinf.text            
+            sline.memo = sline.memo or refinf.text
         return sline
 
     def _parse_date(self, dtnode: Optional[ET.Element]) -> Optional[datetime.datetime]:

--- a/tests/test_iso20022.py
+++ b/tests/test_iso20022.py
@@ -157,7 +157,7 @@ def test_parse_camt052() -> None:
     assert line0.date == datetime.datetime(2021, 2, 5, 0, 0)
     assert line0.date_user == datetime.datetime(2021, 2, 5, 0, 0)
     assert line0.id is None
-    assert line0.memo == "Something"
+    assert line0.memo == "BELASTUNG"
     assert line0.payee == "SPARKASSE PFORZHEIM CALW"
     assert line0.refnum == "NONREF"
 

--- a/tests/test_iso20022.py
+++ b/tests/test_iso20022.py
@@ -40,10 +40,10 @@ def test_parse_simple() -> None:
     line0 = stmt.lines[0]
 
     assert line0.amount == Decimal("-0.29")
-    assert line0.memo == u"Sąskaitos aptarnavimo mokestis"
+    assert line0.memo == "Sąskaitos aptarnavimo mokestis"
     assert line0.date == datetime.datetime(2016, 1, 1, 0, 0)
     assert line0.date_user == datetime.datetime(2015, 12, 31, 0, 0)
-    assert line0.payee == u"AB DNB Bankas"
+    assert line0.payee == "AB DNB Bankas"
     assert line0.refnum == "FC1261858984"
 
 
@@ -174,6 +174,7 @@ def test_unsupported() -> None:
     with pytest.raises(exceptions.ParseError):
         parser.parse()
 
+
 def test_parse_camt053() -> None:
     # GIVEN
     config = {"iban": "CHxxxxxxxxxxxxxxxxxxx"}
@@ -202,8 +203,8 @@ def test_parse_camt053() -> None:
     line0 = stmt.lines[0]
 
     assert line0.amount == Decimal("1284.30")
-    assert line0.memo == u"PAYMENT INFO"
+    assert line0.memo == "PAYMENT INFO"
     assert line0.date == datetime.datetime(2023, 1, 25, 0, 0)
     assert line0.date_user == datetime.datetime(2023, 1, 25, 0, 0)
-    #assert line0.payee == u"PAYEE"
+    # assert line0.payee == u"PAYEE"
     assert line0.refnum == "A032-J30K20-03-JF021"


### PR DESCRIPTION
In the Postfinance statements the `NtryDtls/TxDtls/RmtInf/Strd/CdtrRefInf/Ref` field is an actual reference number and the description is in `AddtlNtryInf`.

This changesalways stores  `NtryDtls/TxDtls/RmtInf/Strd/CdtrRefInf/Ref`  into the ` StatementLine.check_no`, and only uses it as the memo if the other sources have failed.
