### PR TITLE
Swap date and date_user

### DIFF
--- a/src/ofxstatement/plugins/iso20022.py
+++ b/src/ofxstatement/plugins/iso20022.py
@@ -207,10 +207,10 @@ class Iso20022Parser(AbstractStatementParser):
         sline.amount = amt
 
         dt = self._find(ntry, "ValDt")
-        sline.date = self._parse_date(dt)
+        sline.date_user = self._parse_date(dt)
 
         bookdt = self._find(ntry, "BookgDt")
-        sline.date_user = self._parse_date(bookdt)
+        sline.date = self._parse_date(bookdt)
 
         svcref = self._find(ntry, "NtryDtls/TxDtls/Refs/AcctSvcrRef")
         if svcref is None:

--- a/tests/test_iso20022.py
+++ b/tests/test_iso20022.py
@@ -41,8 +41,8 @@ def test_parse_simple() -> None:
 
     assert line0.amount == Decimal("-0.29")
     assert line0.memo == "Sąskaitos aptarnavimo mokestis"
-    assert line0.date == datetime.datetime(2016, 1, 1, 0, 0)
-    assert line0.date_user == datetime.datetime(2015, 12, 31, 0, 0)
+    assert line0.date_user == datetime.datetime(2016, 1, 1, 0, 0)
+    assert line0.date == datetime.datetime(2015, 12, 31, 0, 0)
     assert line0.payee == "AB DNB Bankas"
     assert line0.refnum == "FC1261858984"
 
@@ -123,8 +123,8 @@ def test_parse_davider80() -> None:
 
     assert line0.amount == Decimal("-905.3")
     assert line0.memo == "Sistema di addebitamento diretto xxxxxxxxxxxxxxxxxxxxxx AG"
-    assert line0.date == datetime.datetime(2017, 4, 3, 0, 0)
-    assert line0.date_user == datetime.datetime(2017, 4, 1, 0, 0)
+    assert line0.date_user == datetime.datetime(2017, 4, 3, 0, 0)
+    assert line0.date == datetime.datetime(2017, 4, 1, 0, 0)
     assert line0.payee is None
     assert line0.refnum == "210564431020000000024556150000"
 


### PR DESCRIPTION
The balance provided in the Postfinance statements refers to the booking date, not the value date.
With the value date, the balances are all out of whack with the statement.