### PR TITLE
Add support for debit balance

### DIFF
--- a/src/ofxstatement/plugins/iso20022.py
+++ b/src/ofxstatement/plugins/iso20022.py
@@ -136,7 +136,11 @@ class Iso20022Parser(AbstractStatementParser):
             if amt_ccy != self.statement.currency:
                 continue
 
-            bal_amts[cd.text] = self._parse_amount(amt)
+            cdtdbtind = bal.find("./s:CdtDbtInd", self.xmlns)
+            credit: bool = cdtdbtind is None or cdtdbtind.text == CD_CREDIT
+            bal_amts[cd.text] = (
+                self._parse_amount(amt) if credit else -self._parse_amount(amt)
+            )
             bal_dates[cd.text] = self._parse_date(dt)
 
         if not bal_amts:


### PR DESCRIPTION
The balance can be either credit or debit but the current code assumes it's always credit, so the balance calculation can end up incorrect.